### PR TITLE
fix: consensus/misc/eip4844: implement EIP-7918 (ethereum#31965) 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,18 +1,20 @@
-name: i386 linux tests
-
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: self-hosted-ghr
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: false
 
     # Cache build tools to avoid downloading them each time
     - uses: actions/cache@v4
@@ -23,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.0
+        go-version: 1.24
         cache: false
 
     - name: Run linters
@@ -32,17 +34,25 @@ jobs:
         go run build/ci.go check_generate
         go run build/ci.go check_baddeps
 
-  build:
-    runs-on: self-hosted
+  test:
+    name: Test
+    needs: lint
+    runs-on: self-hosted-ghr
+    strategy:
+      matrix:
+        go:
+          - '1.24'
+          - '1.23'
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.0
+          go-version: ${{ matrix.go }}
           cache: false
+
       - name: Run tests
-        run: go test -short ./...
-        env:
-          GOOS: linux
-          GOARCH: 386
+        run: go test ./...

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -116,7 +116,7 @@ func (l *limbo) finalize(final *types.Header) {
 	// Just in case there's no final block yet (network not yet merged, weird
 	// restart, sethead, etc), fail gracefully.
 	if final == nil {
-		log.Error("Nil finalized block cannot evict old blobs")
+		log.Warn("Nil finalized block cannot evict old blobs")
 		return
 	}
 	for block, ids := range l.groups {
@@ -139,11 +139,11 @@ func (l *limbo) push(tx *types.Transaction, block uint64) error {
 	// If the blobs are already tracked by the limbo, consider it a programming
 	// error. There's not much to do against it, but be loud.
 	if _, ok := l.index[tx.Hash()]; ok {
-		log.Error("Limbo cannot push already tracked blobs", "tx", tx)
+		log.Error("Limbo cannot push already tracked blobs", "tx", tx.Hash())
 		return errors.New("already tracked blob transaction")
 	}
 	if err := l.setAndIndex(tx, block); err != nil {
-		log.Error("Failed to set and index limboed blobs", "tx", tx, "err", err)
+		log.Error("Failed to set and index limboed blobs", "tx", tx.Hash(), "err", err)
 		return err
 	}
 	return nil

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -41,6 +41,7 @@ var activators = map[int]func(*JumpTable){
 	1153: enable1153,
 	4762: enable4762,
 	7702: enable7702,
+	7939: enable7939,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -293,10 +294,26 @@ func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	return nil, nil
 }
 
+// opCLZ implements the CLZ opcode (count leading zero bytes)
+func opCLZ(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	x := scope.Stack.peek()
+	x.SetUint64(256 - uint64(x.BitLen()))
+	return nil, nil
+}
+
 // enable4844 applies EIP-4844 (BLOBHASH opcode)
 func enable4844(jt *JumpTable) {
 	jt[BLOBHASH] = &operation{
 		execute:     opBlobHash,
+		constantGas: GasFastestStep,
+		minStack:    minStack(1, 1),
+		maxStack:    maxStack(1, 1),
+	}
+}
+
+func enable7939(jt *JumpTable) {
+	jt[CLZ] = &operation{
+		execute:     opCLZ,
 		constantGas: GasFastestStep,
 		minStack:    minStack(1, 1),
 		maxStack:    maxStack(1, 1),

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -972,3 +972,43 @@ func TestPush(t *testing.T) {
 		}
 	}
 }
+
+func TestOpCLZ(t *testing.T) {
+	evm := NewEVM(BlockContext{}, nil, params.TestChainConfig, Config{})
+
+	tests := []struct {
+		inputHex string
+		want     uint64 // expected CLZ result
+	}{
+		{"0x0", 256},
+		{"0x1", 255},
+		{"0x6ff", 245},        // 0x6ff = 0b11011111111 (11 bits), so 256-11 = 245
+		{"0xffffffffff", 216}, // 40 bits, so 256-40 = 216
+		{"0x4000000000000000000000000000000000000000000000000000000000000000", 1},
+		{"0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 1},
+		{"0x8000000000000000000000000000000000000000000000000000000000000000", 0},
+		{"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0},
+	}
+	for _, tc := range tests {
+		// prepare a fresh stack and PC
+		stack := newstack()
+		pc := uint64(0)
+
+		// parse input
+		val := new(uint256.Int)
+		if err := val.SetFromHex(tc.inputHex); err != nil {
+			t.Fatal("invalid hex uint256:", tc.inputHex)
+		}
+
+		stack.push(val)
+		opCLZ(&pc, evm.interpreter, &ScopeContext{Stack: stack})
+
+		if gotLen := stack.len(); gotLen != 1 {
+			t.Fatalf("stack length = %d; want 1", gotLen)
+		}
+		result := stack.pop()
+		if got := result.Uint64(); got != tc.want {
+			t.Fatalf("clz(%q) = %d; want %d", tc.inputHex, got, tc.want)
+		}
+	}
+}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -181,10 +181,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	}
 
 	var (
-		op          OpCode        // current opcode
-		mem         = NewMemory() // bound memory
-		stack       = newstack()  // local stack
-		callContext = &ScopeContext{
+		op          OpCode     // current opcode
+		jumpTable   *JumpTable = in.table
+		mem                    = NewMemory() // bound memory
+		stack                  = newstack()  // local stack
+		callContext            = &ScopeContext{
 			Memory:   mem,
 			Stack:    stack,
 			Contract: contract,
@@ -227,6 +228,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// explicit STOP, RETURN or SELFDESTRUCT is executed, an error occurred during
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
+	_ = jumpTable[0] // nil-check the jumpTable out of the loop
 	for {
 		if debug {
 			// Capture pre-execution values for tracing.
@@ -247,7 +249,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// Get the operation from the jump table and validate the stack to ensure there are
 		// enough stack items available to perform the operation.
 		op = contract.GetOp(pc)
-		operation := in.table[op]
+		operation := jumpTable[op]
 		cost = operation.constantGas // For tracing
 		// Validate stack
 		if sLen := stack.len(); sLen < operation.minStack {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -106,6 +106,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
+	case evm.chainRules.IsOsaka:
+		table = &osakaInstructionSet
 	case evm.chainRules.IsVerkle:
 		// TODO replace with proper instruction set when fork is specified
 		table = &verkleInstructionSet

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -62,6 +62,7 @@ var (
 	cancunInstructionSet           = newCancunInstructionSet()
 	verkleInstructionSet           = newVerkleInstructionSet()
 	pragueInstructionSet           = newPragueInstructionSet()
+	osakaInstructionSet            = newOsakaInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -88,6 +89,12 @@ func validate(jt JumpTable) JumpTable {
 func newVerkleInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable4762(&instructionSet)
+	return validate(instructionSet)
+}
+
+func newOsakaInstructionSet() JumpTable {
+	instructionSet := newPragueInstructionSet()
+	enable7939(&instructionSet) // EIP-7939 (CLZ opcode)
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -29,7 +29,7 @@ func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 	case rules.IsVerkle:
 		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
 	case rules.IsOsaka:
-		return newPragueInstructionSet(), errors.New("osaka-fork not defined yet")
+		return newOsakaInstructionSet(), nil
 	case rules.IsPrague:
 		return newPragueInstructionSet(), nil
 	case rules.IsCancun:

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -62,6 +62,7 @@ const (
 	SHL    OpCode = 0x1b
 	SHR    OpCode = 0x1c
 	SAR    OpCode = 0x1d
+	CLZ    OpCode = 0x1e
 )
 
 // 0x20 range - crypto.
@@ -282,6 +283,7 @@ var opCodeToString = [256]string{
 	SHL:    "SHL",
 	SHR:    "SHR",
 	SAR:    "SAR",
+	CLZ:    "CLZ",
 	ADDMOD: "ADDMOD",
 	MULMOD: "MULMOD",
 
@@ -484,6 +486,7 @@ var stringToOp = map[string]OpCode{
 	"SHL":             SHL,
 	"SHR":             SHR,
 	"SAR":             SAR,
+	"CLZ":             CLZ,
 	"ADDMOD":          ADDMOD,
 	"MULMOD":          MULMOD,
 	"KECCAK256":       KECCAK256,

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -17,19 +17,18 @@
 package flags
 
 import (
-	"os/user"
 	"runtime"
 	"testing"
 )
 
 func TestPathExpansion(t *testing.T) {
-	user, _ := user.Current()
+	home := HomeDir()
 	var tests map[string]string
 
 	if runtime.GOOS == "windows" {
 		tests = map[string]string{
 			`/home/someuser/tmp`:        `\home\someuser\tmp`,
-			`~/tmp`:                     user.HomeDir + `\tmp`,
+			`~/tmp`:                     home + `\tmp`,
 			`~thisOtherUser/b/`:         `~thisOtherUser\b`,
 			`$DDDXXX/a/b`:               `\tmp\a\b`,
 			`/a/b/`:                     `\a\b`,
@@ -40,7 +39,7 @@ func TestPathExpansion(t *testing.T) {
 	} else {
 		tests = map[string]string{
 			`/home/someuser/tmp`:        `/home/someuser/tmp`,
-			`~/tmp`:                     user.HomeDir + `/tmp`,
+			`~/tmp`:                     home + `/tmp`,
 			`~thisOtherUser/b/`:         `~thisOtherUser/b`,
 			`$DDDXXX/a/b`:               `/tmp/a/b`,
 			`/a/b/`:                     `/a/b`,

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -173,6 +173,7 @@ const (
 	BlobTxBlobGasPerBlob               = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
 	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
 	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
+	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
 )


### PR DESCRIPTION
## Summary by Sourcery

Implement EIP-7918 support by extending blob gas accounting, introduce and test the CLZ opcode per EIP-7939, update interpreter fork handling, refine logging, and revise CI workflows

New Features:
- Implement EIP-7918 post-Osaka blob gas calculation in CalcExcessBlobGas
- Add CLZ opcode (EIP-7939) to the EVM including implementation, activation, and jump table entries

Enhancements:
- Integrate an Osaka-specific instruction set and update the interpreter to select it based on fork rules
- Introduce calcBlobPrice helper for blob fee computations
- Refactor limbo logging to warn on nil final block and log transaction hashes instead of full tx objects

CI:
- Revise GitHub Actions workflows with a Go version matrix, updated runner labels, job renaming, and submodule checkout settings

Tests:
- Add unit tests for CalcExcessBlobGas under EIP-7918 conditions
- Add TestOpCLZ cases covering various leading zero count scenarios
- Update flags test to use HomeDir() for path expansion

Chores:
- Define BlobBaseCost constant in protocol parameters