### PR TITLE
eth/downloader: fix incorrect waitgroup in test `XTestDelivery` (#33047)

### DIFF
--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -351,6 +351,7 @@ func XTestDelivery(t *testing.T) {
 			}
 		}
 	}()
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		// reserve receiptfetch


### PR DESCRIPTION
## Summary by Sourcery

Fix a deadlock in the XTestDelivery test by correctly incrementing the WaitGroup before starting the goroutine.

Bug Fixes:
- Correct WaitGroup synchronization in XTestDelivery test by adding the missing wg.Add(1) call.

Tests:
- Add missing wg.Add(1) before launching the goroutine in XTestDelivery to ensure proper synchronization.