### PR TITLE
Update validate_pr.yml

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -29,7 +29,13 @@ jobs:
 
             const match = prTitle.match(titleRegex);
             const dirPart = match[1];
-            const directories = dirPart.split(',').map(d => d.trim());
+            const rawDirectories = dirPart.split(',').map(d => d.trim());
+            const hasEmptyDirectory = rawDirectories.some(d => !d);
+            if (hasEmptyDirectory) {
+              core.setFailed(`PR title "${prTitle}" contains empty directory names. Please remove extra commas or spaces.`);
+              return;
+            }
+            const directories = rawDirectories.filter(Boolean);
             const missingDirs = [];
             for (const dir of directories) {
               const fullPath = path.join(process.env.GITHUB_WORKSPACE, dir);


### PR DESCRIPTION
## Summary by Sourcery

Tighten PR title validation and workflow permissions in the PR format validation workflow.

CI:
- Restrict validate_pr workflow permissions to read-only repository contents.
- Ensure the validate_pr job checks out the repository before running validation scripts.
- Extend PR title validation to fail when referenced directories in the title do not exist in the repository.