### PR TITLE
Update validate_pr.yml (#75)

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,4 +1,6 @@
 name: PR Format Validation
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -8,10 +10,15 @@ jobs:
   validate-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check PR Title Format
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
+            const path = require('path');
             const prTitle = context.payload.pull_request.title;
             const titleRegex = /^([\w\s,{}/.]+): .+/;
             
@@ -19,4 +26,27 @@ jobs:
               core.setFailed(`PR title "${prTitle}" does not match required format: directory, ...: description`);
               return;
             }
+
+            const match = prTitle.match(titleRegex);
+            const dirPart = match[1];
+            const rawDirectories = dirPart.split(',').map(d => d.trim());
+            const hasEmptyDirectory = rawDirectories.some(d => !d);
+            if (hasEmptyDirectory) {
+              core.setFailed(`PR title "${prTitle}" contains empty directory names. Please remove extra commas or spaces.`);
+              return;
+            }
+            const directories = rawDirectories.filter(Boolean);
+            const missingDirs = [];
+            for (const dir of directories) {
+              const fullPath = path.join(process.env.GITHUB_WORKSPACE, dir);
+              if (!fs.existsSync(fullPath)) {
+                missingDirs.push(dir);
+              }
+            }
+            
+            if (missingDirs.length > 0) {
+              core.setFailed(`The following directories in the PR title do not exist: ${missingDirs.join(', ')}`);
+              return;
+            }
+            
             console.log('✅ PR title format is valid');


### PR DESCRIPTION
* Update validate_pr.yml Tighten PR title validation and workflow permissions in the PR format validation workflow.

CI:

Restrict validate_pr workflow permissions to read-only repository contents. Ensure the validate_pr job checks out the repository before running validation scripts. Extend PR title validation to fail when referenced directories in the title do not exist in the repository.


* Update .github/workflows/validate_pr.yml




---------

## Summary by Sourcery

Tighten the PR format validation workflow by restricting permissions, checking out the repository, and enforcing that directories referenced in PR titles actually exist.

CI:
- Restrict the PR validation workflow to read-only repository contents and add an explicit checkout step before running validation scripts.
- Enhance PR title validation to reject titles with empty directory entries or directories that do not exist in the repository.