### PR TITLE
Update validate_pr.yml (#75) (#77)

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -35,9 +35,8 @@ jobs:
               core.setFailed(`PR title "${prTitle}" contains empty directory names. Please remove extra commas or spaces.`);
               return;
             }
-            const directories = rawDirectories.filter(Boolean);
             const missingDirs = [];
-            for (const dir of directories) {
+            for (const dir of rawDirectories) {
               const fullPath = path.join(process.env.GITHUB_WORKSPACE, dir);
               if (!fs.existsSync(fullPath)) {
                 missingDirs.push(dir);


### PR DESCRIPTION
* Update validate_pr.yml Tighten PR title validation and workflow permissions in the PR format validation workflow.

CI:

Restrict validate_pr workflow permissions to read-only repository contents. Ensure the validate_pr job checks out the repository before running validation scripts. Extend PR title validation to fail when referenced directories in the title do not exist in the repository.


* Update .github/workflows/validate_pr.yml




---------

## Summary by Sourcery

Tighten the PR title validation workflow and restrict its GitHub Actions permissions.

CI:
- Restrict the PR format validation workflow to read-only repository contents permissions and ensure it checks out the repository before running.
- Extend PR title validation to reject titles with empty directory segments or directories that do not exist in the repository.